### PR TITLE
Add trailing comment required by package.el

### DIFF
--- a/maxframe.el
+++ b/maxframe.el
@@ -201,3 +201,5 @@ system."
 (defalias 'mf 'maximize-frame)
 
 (provide 'maxframe)
+
+;;; maxframe.el ends here


### PR DESCRIPTION
It's pedantic, but package.el requires the "blah.el ends here" comment in order to consider a library's metadata well-formed. This commit adds that line. :-)

-Steve
