### PR TITLE
Get size from the target display not from the current display

### DIFF
--- a/maxframe.el
+++ b/maxframe.el
@@ -174,8 +174,8 @@ specified by HEIGHT."
       (when (and mf-restore-width mf-restore-height mf-restore-top mf-restore-left)
         (set-frame-size target-frame mf-restore-width mf-restore-height)
         (set-frame-position target-frame
-                            (if (consp mf-restore-left) 0 mf-restore-left)
-                          mf-restore-top))
+                            (if (consp mf-restore-left) (car (cdr mf-restore-left)) mf-restore-left)
+                            (if (consp mf-restore-top)  (car (cdr mf-restore-top))  mf-restore-top)))
       (set-frame-parameter target-frame 'mf-maximized      nil)
       (set-frame-parameter target-frame 'mf-restore-width  nil)
       (set-frame-parameter target-frame 'mf-restore-height nil)


### PR DESCRIPTION
Current `x-maximize-frame` gets the display width from the current display, not from the target display.
If we have multiple displays and both resolutions are different, it takes wrong size as the new frame size.

for example, I have two displays:
1.  MacBook Pro "15 (first screen 1440x900)
2. Thunderbolt "27 display (second screen 2560x1440)
   and, current frame is located on the thunderbolt display,
   then, `x-maximize-frame` makes 2560x1440 frame on the first screen.

After applying this PR, it will make 440x900 frame on the first screen.
It works with Emacs 24.3 and Mavericks, but I believe it also works with other environments.
